### PR TITLE
For better integration with VisualEditor: add tag hook support

### DIFF
--- a/Widgets.php
+++ b/Widgets.php
@@ -75,6 +75,7 @@ $wgHooks['CanonicalNamespaces'][] = 'widgetsAddNamespaces';
  */
 function widgetParserFunctions( &$parser ) {
 	$parser->setFunctionHook( 'widget', 'WidgetRenderer::renderWidget' );
+	$parser->setHook( 'widget', 'WidgetRenderer::renderWidgetTag' );
 
 	return true;
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -9,5 +9,6 @@
 	"grouppage-widgeteditor": "{{ns:project}}:Widget editors",
 	"right-editwidgets": "Create and edit [https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:Widgets widgets] in the <code>{{ns:widget}}</code> namespace",
 	"group-widgeteditor.css": "/* CSS placed here will affect widget editors only */",
-	"group-widgeteditor.js": "/* JS placed here will affect widget editors only */"
+	"group-widgeteditor.js": "/* JS placed here will affect widget editors only */",
+	"widgets-error-widgetname-parameter-mandatory": "Parametern 'widgetname' måste anges."
 }

--- a/i18n/sv.json
+++ b/i18n/sv.json
@@ -12,5 +12,6 @@
 	"group-widgeteditor": "Widget-redigerare",
 	"group-widgeteditor-member": "{{GENDER:$1|widget-redigerare}}",
 	"grouppage-widgeteditor": "{{ns:project}}:Widget-redigerare",
-	"right-editwidgets": "Skapa och redigera [https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:Widgets widgets] i namnrymden<tt>{{ns:widget}}</tt>"
+	"right-editwidgets": "Skapa och redigera [https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:Widgets widgets] i namnrymden<tt>{{ns:widget}}</tt>",
+    "widgets-error-widgetname-parameter-mandatory": "The parameter 'widgetname' is mandatory."
 }


### PR DESCRIPTION
In order to get a widget to render properly inside VisualEditor, it can be called using a tag-hook with this syntax:

```
{{#tag:widget||widgetname=WidgetName|parameter={{{parameter|}}}}}
```

Only the above syntax will work.  Neither the widget parser function ({{#widget: ...}}) nor the widget tag hook (<widget> added by this patch) will render properly inside VisualEditor.
