### PR TITLE
Move "editwidgets" right to "interface-admin".

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -58,7 +58,7 @@
 		"widgeteditor": {
 			"editwidgets": true
 		},
-		"sysop": {
+		"interface-admin": {
 			"editwidgets": true
 		}
 	},


### PR DESCRIPTION
I would like to suggest granting the "editwidgets" right to "interface-admin" instead of "sysop". Since the use of insecure widget code can potentially compromise the security of the wiki, it would be a good idea to require the user to be an Interface administrator rather than a regular Administrator/Sysop (the "interface-admin" group was added in an update to MediaWiki to help prevent a rogue Administrator from adding dangerous code to the wiki interface).